### PR TITLE
Add validation for Wavefile formats.

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -1,6 +1,16 @@
 package internal
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
+
+type wrappingError struct {
+	message  string
+	wrapping error
+}
+
+var _ interface{ Unwrap() error } = wrappingError{}
 
 var (
 	// ErrClosed represents the case where a reader or
@@ -15,3 +25,59 @@ var (
 	// parse a chunk but the data is in an invalid format.
 	ErrBadChunk error = errors.New("invalid chunk")
 )
+
+// Wrap returns a new error with the given message,
+// such that when Wrap() is called, the provided
+// error is returned; in other words, Wrap will
+// return an error that wraps "err" with a new
+// message ("msg")
+//
+// Passing a nil error is not allowed and will
+// result in panic.
+func Wrap(msg string, err error) error {
+	if err != nil {
+		return wrappingError{
+			message:  msg,
+			wrapping: err,
+		}
+	}
+
+	Panic("cannot wrap nil error")
+
+	return nil // Satisifies compiler.
+}
+
+// Panic will cause the application to panic
+// with the provided value, ensuring it will
+// some how be prefix with "goriffa".
+//
+// If the value is an error, then it is wrapped
+// via Wrap and the panic value will be the
+// wrapped error.
+//
+// If the value is a string, then the panic
+// value is said string with "goriffa: "
+// prepended.
+//
+// Otherwise, the panic value is equivalent
+// to:
+//  fmt.Sprintf("goriffa: %v", v)
+func Panic(v interface{}) {
+	const prefix = "goriffa: "
+	switch concrete := v.(type) {
+	case error:
+		panic(Wrap(prefix+concrete.Error(), concrete))
+	case string:
+		panic(fmt.Errorf("%s%s", prefix, concrete))
+	default:
+		panic(fmt.Errorf("%s%v", prefix, concrete))
+	}
+}
+
+func (e wrappingError) Unwrap() error {
+	return e.wrapping
+}
+
+func (e wrappingError) Error() string {
+	return e.message
+}

--- a/internal/errors_test.go
+++ b/internal/errors_test.go
@@ -1,0 +1,52 @@
+package internal_test
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/standoffvenus/goriffa/internal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrap(t *testing.T) {
+	err := errors.New("original")
+	wrapped := internal.Wrap("new", err)
+
+	assert.Equal(t, "new", wrapped.Error())
+	assert.ErrorIs(t, wrapped, err)
+	assert.Equal(t, err, errors.Unwrap(wrapped))
+}
+
+func TestPanicOnError(t *testing.T) {
+	err := errors.New("error")
+
+	confirmPanics(t, err.Error(), func() { internal.Panic(err) })
+}
+
+func TestPanicOnString(t *testing.T) {
+	str := "error"
+
+	confirmPanics(t, str, func() { internal.Panic(str) })
+}
+
+func TestPanicGeneric(t *testing.T) {
+	var i int64 = 42
+
+	confirmPanics(t, strconv.FormatInt(i, 10), func() { internal.Panic(i) })
+}
+
+func confirmPanics(t *testing.T, expectingString string, testingFunc func()) {
+	defer func() {
+		v := recover()
+		assert.NotNil(t, v, "Expected function to panic, but received nil recovery value!")
+
+		err, _ := v.(error)
+		if assert.Error(t, err) {
+			assert.Equal(t, fmt.Sprintf("goriffa: %s", expectingString), err.Error())
+		}
+	}()
+
+	testingFunc()
+}

--- a/internal/io.go
+++ b/internal/io.go
@@ -125,12 +125,12 @@ func WriteAt(w io.WriterAt, b []byte, offset int64) (int, error) {
 // array.
 func Must4Byte(b []byte) [4]byte {
 	if len(b) != 4 {
-		panic(fmt.Errorf("wrong number of bytes: %d", len(b)))
+		Panic(fmt.Errorf("wrong number of bytes: %d", len(b)))
 	}
 
 	var array [4]byte
 	if n := copy(array[:], b); n != 4 {
-		panic(fmt.Errorf("wrong number of bytes copied: %d", n))
+		Panic(fmt.Errorf("wrong number of bytes copied: %d", n))
 	}
 
 	return array
@@ -151,7 +151,7 @@ func ReadLittleEndianUInt16(r io.ByteReader) uint16 {
 	for i := 0; i < cap(bytes); i++ {
 		b, err := r.ReadByte()
 		if err != nil {
-			panic(err)
+			Panic(err)
 		}
 		bytes = append(bytes, b)
 	}
@@ -167,7 +167,7 @@ func ReadLittleEndianUInt32(r io.ByteReader) uint32 {
 	for i := 0; i < cap(bytes); i++ {
 		b, err := r.ReadByte()
 		if err != nil {
-			panic(err)
+			Panic(err)
 		}
 		bytes = append(bytes, b)
 	}

--- a/internal/test/buffer.go
+++ b/internal/test/buffer.go
@@ -3,6 +3,8 @@ package test
 import (
 	"bytes"
 	"io"
+
+	"github.com/standoffvenus/goriffa/internal"
 )
 
 // Buffer extends bytes.Buffer to implement
@@ -16,7 +18,7 @@ var _ io.WriterAt = new(Buffer)
 func (buf *Buffer) WriteAt(b []byte, offset int64) (int, error) {
 	currentBytes := buf.Bytes()
 	if offset > int64(len(currentBytes)) {
-		panic("offset out of bounds")
+		internal.Panic("offset out of bounds")
 	}
 
 	n := copy(currentBytes[offset:], b)

--- a/wave/wave.go
+++ b/wave/wave.go
@@ -25,6 +25,46 @@ const (
 	PCM AudioFormat = 1
 )
 
+var (
+	// ErrBadWaveData occurs when errors in Wavefile
+	// data are recognized, such as invalid block
+	// alignment, unrecognized audio formats, etc.
+	//
+	// ErrBadWaveData wraps goriffa.ErrCorrupted so
+	//  if errors.Is(err, goriffa.ErrCorrupted) {
+	// can be used to generally capture errors when
+	// reading/writing Wavefile data.
+	//
+	// All Wavefile errors wrap ErrBadWaveData.
+	ErrBadWaveData error = internal.Wrap("invalid Wavefile data", internal.ErrCorrupted)
+
+	// ErrUnrecognizedAudioFormat occurs when an unrecognized
+	// audio format integer is in the Wavefile data.
+	ErrUnrecognizedAudioFormat error = internal.Wrap("unrecognized audio format", ErrBadWaveData)
+
+	// ErrInvalidChannelCount occurs when a Wavefile's
+	// channel count is 0.
+	ErrInvalidChannelCount error = internal.Wrap("invalid channel count", ErrBadWaveData)
+
+	// ErrInvalidSampleRate occurs when a Wavefile's
+	// sample rate is 0.
+	ErrInvalidSampleRate error = internal.Wrap("invalid sample rate", ErrBadWaveData)
+
+	// ErrInconsistentBytesPerSecond occurs when the average
+	// bytes-per-second field of the Wavefile data
+	// does not match SampleRate * Channels * BitRate / 8.
+	ErrInconsistentBytesPerSecond error = internal.Wrap("bytes per second was inconsistent", ErrBadWaveData)
+
+	// ErrInconsistentBlockAlignment occurs when the block
+	// alignment bytes for a Wavefile is erroneous
+	// given the channel count and bits per sample.
+	ErrInconsistentBlockAlignment error = internal.Wrap("block alignment was inconsistent", ErrBadWaveData)
+
+	// ErrInvalidBitRate occurs when a Wavefile's bit rate
+	// is 0 or not a multiple of 8.
+	ErrInvalidBitRate error = internal.Wrap("invalid bit rate", ErrBadWaveData)
+)
+
 // FileTypeWavefile represents the file type
 // stored in a Wavefile ("WAVE")
 var FileTypeWavefile internal.FileType = internal.Must4Byte([]byte("WAVE"))
@@ -35,29 +75,56 @@ type AudioFormat uint16
 
 // Format represents details about a
 // Wavefile.
+//
+// The format chunk for Wavefile data is
+// formatted as follows (all numbers are
+// little-endian):
+//  [24]byte{
+//    fmt                    // 4 bytes for chunk identifier ("fmt " in this case)
+//    0x10, 0, 0, 0          // 4 bytes for chunk length (always 16 for format chunks)
+//    1, 0                   // 2 bytes for audio format (1 represents PCM)
+//    2, 0                   // 2 bytes for channel count (2 channels)
+//    0x44, 0xAC, 0, 0       // 4 bytes for sample rate (44100Hz)
+//    0x10, 0xB1, 0x02, 0x00 // 4 bytes expected to be (Sample Rate * BitsPerSample * Channels) / 8 == 172400
+//    4, 0                   // 2 bytes for block alignment: (BitsPerSample / 8 * Channels) == 4
+//    0x10, 0                // 2 bytes for bits per sample
+//  }
 type Format struct {
 	// BitsPerSample will return how many
 	// bits a sample in the Wavefile is
 	// encoded with.
+	// Bits per sample must be a non-zero
+	// multiple of 8.
 	BitsPerSample uint16
 
 	// Channels will return the number of
 	// channels of a Wavefile.
+	// While the channel count cannot be
+	// 0, any other channel count is
+	// technically allowed.
 	Channels uint16
 
 	// SampleRate will return the sample
 	// rate of a Wavefile.
+	// Sample rate
 	SampleRate uint32
 
 	// AudioFormat will return the audio
 	// format of the Wavefile, such as
 	// PCM.
+	// The audio format must be a supported
+	// audio format.
+	//
+	// TODO: Support more than PCM.
 	AudioFormat AudioFormat
 }
 
 // WritePCM will write PCM data to the provided RIFF writer
 // in the Wavefile format. The number of bytes written and
-// any error will be returned.
+// any error will be returned. If the Wavefile format fails
+// to validate, the corresponding error is returned. If the
+// provided format's audio format is not PCM, ErrBadWaveData
+// is returned.
 //
 // The provided format will be written as the Wavefile's format
 // header, whereas the PCM data provided will be written in the
@@ -66,6 +133,15 @@ type Format struct {
 // The writer is expected to be initialized - that is, the RIFF
 // header is expected to be written to the writer already.
 func WritePCM(w goriffa.Writer, f Format, pcm []byte) (int, error) {
+	if err := Validate(f); err != nil {
+		return 0, err
+	}
+	if f.AudioFormat != PCM {
+		return 0, fmt.Errorf(
+			"%w: attempt to write PCM data with non-PCM audio format",
+			ErrBadWaveData)
+	}
+
 	data := formatToBytes(f)
 	fmtN, fmtErr := w.WriteChunk(internal.Chunk{
 		Identifier: goriffa.FourCCFormat,
@@ -96,12 +172,12 @@ func FormatFromReader(r goriffa.Reader) (Format, error) {
 	if n, err := r.ReadChunk(&ch); err != nil {
 		return f, err
 	} else if n != LengthFormatChunk {
-		return f, fmt.Errorf("%w: format chunk is invalid size (%d)", internal.ErrCorrupted, n)
+		return f, fmt.Errorf("%w: format chunk is invalid size (%d)", ErrBadWaveData, n)
 	}
 
 	if ch.Identifier != goriffa.FourCCFormat {
 		return f, fmt.Errorf("%w: format chunk FOURCC incorrect (%s, should be %s)",
-			internal.ErrCorrupted,
+			ErrBadWaveData,
 			string(ch.Identifier[:]),
 			string(goriffa.FourCCFormat[:]))
 	}
@@ -121,7 +197,7 @@ func FormatFromReader(r goriffa.Reader) (Format, error) {
 	if expectedBytesPerSecond != uint32(f.BytesPerSecond()) {
 		return f, fmt.Errorf(
 			"%w: stream has invalid average bytes-per-second field (expected %d, was %d)",
-			internal.ErrCorrupted,
+			ErrInconsistentBytesPerSecond,
 			expectedBytesPerSecond,
 			f.BytesPerSecond(),
 		)
@@ -130,10 +206,14 @@ func FormatFromReader(r goriffa.Reader) (Format, error) {
 	if expectedBlockAlign != uint16(f.BlockAlign()) {
 		return f, fmt.Errorf(
 			"%w: stream contained invalid block alignment (expected %d, was %d)",
-			internal.ErrCorrupted,
+			ErrInconsistentBlockAlignment,
 			expectedBlockAlign,
 			f.BlockAlign(),
 		)
+	}
+
+	if err := Validate(f); err != nil {
+		return f, err
 	}
 
 	return f, nil
@@ -169,8 +249,40 @@ func formatToBytes(f Format) [LengthFormatChunk]byte {
 
 	var rawBytes [LengthFormatChunk]byte
 	if err := internal.Copy(rawBytes[:], formatBuffer); err != nil {
-		panic(err)
+		internal.Panic(err)
 	}
 
 	return rawBytes
+}
+
+// Validate will return an error if the provided
+// format is invalid.
+func Validate(f Format) error {
+	switch {
+	case f.BitsPerSample == 0:
+		return fmt.Errorf(
+			"%w: bit rate cannot be 0",
+			ErrInvalidBitRate,
+		)
+	case f.BitsPerSample%8 != 0:
+		return fmt.Errorf(
+			"%w: bit rate must be a multiple of 8 (was %d)",
+			ErrInvalidBitRate,
+			f.BitsPerSample,
+		)
+	}
+
+	if f.Channels == 0 {
+		return fmt.Errorf(
+			"%w: channel count cannot be 0",
+			ErrInvalidChannelCount)
+	}
+
+	if f.SampleRate == 0 {
+		return fmt.Errorf(
+			"%w: sample rate cannot be 0",
+			ErrInvalidSampleRate)
+	}
+
+	return nil
 }


### PR DESCRIPTION
- Add validation for sample rate.
- Add validation for bit rate.
- Add validation for channel count.
- Add validation for PCM audio format when trying to write PCM data (naive, does not check PCM content
- Add a few internal utilities.

Closes #1.